### PR TITLE
Change to the way the client caches cubes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -46,8 +46,8 @@ const MAX_GET_URI_LENGTH = 2000;
 export default class Client {
 
     private api_base: string;
-    private cubesCache: Cube[];
-    private cubeCache: { [cname: string]: Cube };
+    private cubesCache: Cube[] | Promise<Cube[]>;
+    private cubeCache: { [cname: string]: Cube | Promise<Cube> };
 
     constructor(api_base: string) {
         this.api_base = api_base;


### PR DESCRIPTION
I applied a trick I used to prevent the loading of more than 1 request for the same cube/cube list. It's a bit dirty typings-wise, but it works as intended.